### PR TITLE
fix: inputrules on newline

### DIFF
--- a/src/InputRulesBuilder.ts
+++ b/src/InputRulesBuilder.ts
@@ -11,13 +11,13 @@ export class InputRulesBuilder {
 
   public constructor(
     extensionManager: ExtensionManager,
-    proseMirrorSchema: Schema<string, string>,
+    proseMirrorSchema: Schema<string, string>
   ) {
     this.rules = ([] as Array<InputRule>).concat.apply(
       [],
       extensionManager
         .syntaxExtensions()
-        .map((extension) => extension.proseMirrorInputRules(proseMirrorSchema)),
+        .map((extension) => extension.proseMirrorInputRules(proseMirrorSchema))
     );
   }
 
@@ -34,12 +34,12 @@ export class InputRulesBuilder {
       if (event.key !== "Enter") {
         return originalHandleKeyDown?.(view, event);
       }
-      const { $head } = view.state.selection;
+      const { from, to } = view.state.selection;
       inputRulesPlugin.props.handleTextInput?.call(
         inputRulesPlugin,
         view,
-        $head.pos,
-        $head.pos,
+        from,
+        to,
         "\n",
       );
       return originalHandleKeyDown?.(view, event);

--- a/src/InputRulesBuilder.ts
+++ b/src/InputRulesBuilder.ts
@@ -31,17 +31,16 @@ export class InputRulesBuilder {
       event: KeyboardEvent,
       // eslint-disable-next-line @typescript-eslint/no-invalid-void-type --- original prosemirror api
     ): boolean | void {
-      if (event.key !== "Enter") {
-        return originalHandleKeyDown?.(view, event);
+      if (event.key === "Enter") {
+        const { from, to } = view.state.selection;
+        inputRulesPlugin.props.handleTextInput?.call(
+          inputRulesPlugin,
+          view,
+          from,
+          to,
+          "\n",
+        );
       }
-      const { from, to } = view.state.selection;
-      inputRulesPlugin.props.handleTextInput?.call(
-        inputRulesPlugin,
-        view,
-        from,
-        to,
-        "\n",
-      );
       return originalHandleKeyDown?.(view, event);
     };
     inputRulesPlugin.props.handleKeyDown = customHandleKeyDown;

--- a/src/InputRulesBuilder.ts
+++ b/src/InputRulesBuilder.ts
@@ -11,13 +11,13 @@ export class InputRulesBuilder {
 
   public constructor(
     extensionManager: ExtensionManager,
-    proseMirrorSchema: Schema<string, string>
+    proseMirrorSchema: Schema<string, string>,
   ) {
     this.rules = ([] as Array<InputRule>).concat.apply(
       [],
       extensionManager
         .syntaxExtensions()
-        .map((extension) => extension.proseMirrorInputRules(proseMirrorSchema))
+        .map((extension) => extension.proseMirrorInputRules(proseMirrorSchema)),
     );
   }
 

--- a/src/InputRulesBuilder.ts
+++ b/src/InputRulesBuilder.ts
@@ -1,6 +1,5 @@
 import type { Schema } from "prosemirror-model";
 import type { Plugin } from "prosemirror-state";
-import type { EditorView } from "prosemirror-view";
 
 import { type InputRule, inputRules } from "prosemirror-inputrules";
 
@@ -25,12 +24,10 @@ export class InputRulesBuilder {
     const inputRulesPlugin = inputRules({ rules: this.rules });
     const originalHandleKeyDown =
       inputRulesPlugin.props.handleKeyDown?.bind(inputRulesPlugin);
-    const customHandleKeyDown = function (
-      this: typeof inputRulesPlugin,
-      view: EditorView,
-      event: KeyboardEvent,
-      // eslint-disable-next-line @typescript-eslint/no-invalid-void-type --- original prosemirror api
-    ): boolean | void {
+    const customHandleKeyDown: Exclude<
+      typeof originalHandleKeyDown,
+      undefined
+    > = (view, event) => {
       if (event.key === "Enter") {
         const { from, to } = view.state.selection;
         inputRulesPlugin.props.handleTextInput?.call(

--- a/src/MarkInputRule.ts
+++ b/src/MarkInputRule.ts
@@ -88,7 +88,12 @@ export class MarkInputRule extends InputRule {
       tr.removeStoredMark(markType);
     }
 
-    // Add back the last character
-    return tr.insertText(match[2]);
+    // Add back the last character if it is not a newline,
+    // otherwise omit it because newline is handled out of the text node.
+    if (match[2] !== "\n") {
+      tr.insertText(match[2]);
+    }
+
+    return tr;
   }
 }


### PR DESCRIPTION
Hello, this PR tries to implement the function of executing input rules on newline, which should fix https://github.com/marekdedic/prosemirror-remark/issues/69 and fix https://github.com/marekdedic/prosemirror-remark/issues/71 in the `prosemirror-remark` repo.

The general idea is borrowed from this thread: https://discuss.prosemirror.net/t/trigger-inputrule-on-enter/1118/6

To be more specific, this PR overwrites the `handleKeyDown` method exposed from the plugin in the `build` method of `class InputRulesBuilder`, and manually triggers the `handleTextInput` with a newline `\n` character in the new method. As the regexes defined in the input rules have `\s` in the trailing matches, it will match `\n` and transform the input as expected. Finally, to remove the newline `\n` character from the textnode, I adjusted the `markHandler` method in `class MarkInputRule` so that it will not insert it back if it is a newline character.

No changes are needed in `prosemirror-remark` because `\n` is already matched by the input rules of those defined marks.

Although I tested it locally with `pnpm patch` in my project, I didn't include any tests in this PR, for being not sure about whether this is the correct approach, and I don't quite know how to properly write a test. 