### PR TITLE
Fix extension identity after minification

### DIFF
--- a/src/ExtensionManager.ts
+++ b/src/ExtensionManager.ts
@@ -7,9 +7,15 @@ import { MarkExtension } from "./MarkExtension";
 import { NodeExtension } from "./NodeExtension";
 
 export class ExtensionManager {
-  private readonly markExtensionList: Map<string, MarkExtension<UnistNode>>;
-  private readonly nodeExtensionList: Map<string, NodeExtension<UnistNode>>;
-  private readonly otherExtensionList: Map<string, Extension>;
+  private readonly markExtensionList: Map<
+    Extension["constructor"],
+    MarkExtension<UnistNode>
+  >;
+  private readonly nodeExtensionList: Map<
+    Extension["constructor"],
+    NodeExtension<UnistNode>
+  >;
+  private readonly otherExtensionList: Map<Extension["constructor"], Extension>;
 
   public constructor(extensions: Array<Extension>) {
     this.markExtensionList = new Map();
@@ -47,14 +53,14 @@ export class ExtensionManager {
     }
 
     if (isMarkExtension(extension)) {
-      this.markExtensionList.set(extension.constructor.name, extension);
+      this.markExtensionList.set(extension.constructor, extension);
       return;
     }
     if (isNodeExtension(extension)) {
-      this.nodeExtensionList.set(extension.constructor.name, extension);
+      this.nodeExtensionList.set(extension.constructor, extension);
       return;
     }
-    this.otherExtensionList.set(extension.constructor.name, extension);
+    this.otherExtensionList.set(extension.constructor, extension);
   }
 }
 

--- a/tests/unit/ExtensionManager.test.ts
+++ b/tests/unit/ExtensionManager.test.ts
@@ -104,6 +104,71 @@ test("ExtensionManager manages mark and node extensions", () => {
   ]);
 });
 
+test("ExtensionManager distinguishes extensions with the same constructor name", () => {
+  const MarkExtension1 = class n<
+    UNode extends UnistNode,
+  > extends MockMarkExtension<UNode> {};
+  const MarkExtension2 = class n<
+    UNode extends UnistNode,
+  > extends MockMarkExtension<UNode> {};
+  const NodeExtension1 = class n<
+    UNode extends UnistNode,
+  > extends MockNodeExtension<UNode> {};
+  const NodeExtension2 = class n<
+    UNode extends UnistNode,
+  > extends MockNodeExtension<UNode> {};
+  const Extension1 = class n extends Extension {};
+  const Extension2 = class n extends Extension {};
+  const markExtension1 = vi.mocked(new MarkExtension1());
+  markExtension1.dependencies.mockReturnValueOnce([]);
+  const markExtension2 = vi.mocked(new MarkExtension2());
+  markExtension2.dependencies.mockReturnValueOnce([]);
+  const nodeExtension1 = vi.mocked(new NodeExtension1());
+  nodeExtension1.dependencies.mockReturnValueOnce([]);
+  const nodeExtension2 = vi.mocked(new NodeExtension2());
+  nodeExtension2.dependencies.mockReturnValueOnce([]);
+  const extension1 = vi.mocked(new Extension1());
+  extension1.dependencies.mockReturnValueOnce([]);
+  const extension2 = vi.mocked(new Extension2());
+  extension2.dependencies.mockReturnValueOnce([]);
+  const manager = new ExtensionManager([
+    markExtension1,
+    markExtension2,
+    nodeExtension1,
+    nodeExtension2,
+    extension1,
+    extension2,
+  ]);
+
+  expect(manager.markExtensions()).toStrictEqual([
+    markExtension1,
+    markExtension2,
+  ]);
+  expect(manager.nodeExtensions()).toStrictEqual([
+    nodeExtension1,
+    nodeExtension2,
+  ]);
+  expect(manager.extensions()).toStrictEqual([
+    nodeExtension1,
+    nodeExtension2,
+    markExtension1,
+    markExtension2,
+    extension1,
+    extension2,
+  ]);
+});
+
+test("ExtensionManager deduplicates instances of the same extension", () => {
+  class MockExtension extends Extension {}
+  const extension1 = vi.mocked(new MockExtension());
+  extension1.dependencies.mockReturnValueOnce([]);
+  const extension2 = vi.mocked(new MockExtension());
+  extension2.dependencies.mockReturnValueOnce([]);
+  const manager = new ExtensionManager([extension1, extension2]);
+
+  expect(manager.extensions()).toStrictEqual([extension2]);
+});
+
 test("ExtensionManager manages extensions with dependencies", () => {
   class MarkExtension1<
     UNode extends UnistNode,


### PR DESCRIPTION
Use constructor objects instead of constructor names when deduplicating extensions. This avoids collisions between unrelated minified classes.