### PR TITLE
Migrate coverage reporting from Coveralls to Codecov

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -87,25 +87,19 @@ jobs:
           npm run test-coverage unit
 
       - name: "Upload coverage results"
-        uses: coverallsapp/github-action@v2.3.8
+        uses: codecov/codecov-action@v7.0.0
         with:
-          debug: true
-          parallel: true
-          flag-name: unit
+          flags: unit
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
 
       - name: "Run integration tests"
         run: |
           npm run test-coverage integration
 
       - name: "Upload coverage results"
-        uses: coverallsapp/github-action@v2.3.8
+        uses: codecov/codecov-action@v7.0.0
         with:
-          debug: true
-          parallel: true
-          flag-name: integration
-
-      - name: "Close coverage report"
-        uses: coverallsapp/github-action@v2.3.8
-        with:
-          debug: true
-          parallel-finished: true
+          flags: integration
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM Version](https://img.shields.io/npm/v/prosemirror-unified?logo=npm)](https://www.npmjs.com/package/prosemirror-unified)
 [![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/marekdedic/prosemirror-unified/CI.yml?branch=master&logo=github)](https://github.com/marekdedic/prosemirror-unified/actions/workflows/CI.yml)
-[![Coveralls](https://img.shields.io/coverallsCoverage/github/marekdedic/prosemirror-unified?branch=master&logo=coveralls)](https://coveralls.io/github/marekdedic/prosemirror-unified)
+[![Codecov (with branch)](https://img.shields.io/codecov/c/github/marekdedic/prosemirror-unified/master?logo=codecov)](https://app.codecov.io/gh/marekdedic/prosemirror-unified)
 [![NPM Downloads](https://img.shields.io/npm/dm/prosemirror-unified?logo=npm)](https://www.npmjs.com/package/prosemirror-unified)
 [![NPM License](https://img.shields.io/npm/l/prosemirror-unified)](https://github.com/marekdedic/prosemirror-unified/blob/master/LICENSE)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,24 @@
+---
+coverage:
+  range: "95...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+    patch:
+      default:
+        target: 90%
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: true
+      loop: true
+      method: false
+      macro: false
+
+comment:
+  layout: "reach,diff,flags,files"
+  require_changes: false


### PR DESCRIPTION
Unify coverage reporting on Codecov, which the other repositories already
use, so that all of them report to a single service.

- Replace `coverallsapp/github-action` with `codecov/codecov-action`,
  configured as in the other repositories: an authentication token from
  `secrets.CODECOV_TOKEN` and `fail_ci_if_error: true`.
- Add `codecov.yml`, identical to the one in the other repositories.
- Point the README coverage badge at Codecov.
- Keep the unit and integration reports separate, using Codecov's `flags`
  in place of Coveralls' `flag-name`.
- Drop the "Close coverage report" step. Coveralls needed the two parallel
  uploads to be explicitly finalised; Codecov merges the uploads of a
  commit on its own.

> [!IMPORTANT]
> This repository has no `CODECOV_TOKEN` secret yet. It needs to be added
> (Codecov → repository settings) before merging, otherwise the upload step
> fails and, because of `fail_ci_if_error: true`, takes CI down with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)