### PR TITLE
Don't count test helpers in coverage

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,6 +26,9 @@ export default defineConfig({
   },
   plugins: [dts({ bundleTypes: true })],
   test: {
+    coverage: {
+      exclude: ["tests/**"],
+    },
     environment: "jsdom",
     mockReset: true,
     setupFiles: ["tests/setup.ts"],


### PR DESCRIPTION
The tests directory was being measured as if it were production code.
Vitest's default `coverage.exclude` matches test *file name* patterns
(`**/*.{test,spec}.*`) rather than test *directories*, so files under
`tests/` that don't carry `.test.` in their name were instrumented, because
the tests import them.

In this repository 7 of the 21 measured files were under
`tests/integration/` and `tests/mocks/`, accounting for roughly 22 % of the
measured lines.

Exclude `tests/**` from coverage. Doing this in the vitest config rather than
through `codecov.yml`'s `ignore` key keeps a local `npm run test-coverage` run
consistent with CI, and leaves `codecov.yml` byte-identical across all the
repositories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)