### PR TITLE
Using named capture groups for MarkInputRule

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,27 @@ This class extends the `InputRule` class provided by ProseMirror and should be u
 
 Creates a new input rule that adds the mark specified by `markType` if the user input matches the provided `matcher`.
 
+The `matcher` must end with `$` and must contain two named capturing groups:
+
+- `content` — the text the mark is applied to. The whole match is replaced by this group, which is how the surrounding delimiters (e.g. the asterisks around bold text) get removed.
+- `trailing` — the text typed after the closing delimiter. It is re-inserted verbatim after the mark has been applied, and may be longer than one character. A `trailing` match consisting of a single newline is not re-inserted, because the newline is handled outside of the text node.
+
+The `trailing` group may be made optional, in which case the rule also applies when nothing follows the closing delimiter — the rule then triggers as soon as the delimiter itself is typed:
+
+```ts
+new MarkInputRule(/<b>(?<content>.*)<\/b>(?<trailing>.)?$/u, schema.marks["bold"]);
+```
+
+A rule that never has any trailing text can use an empty group:
+
+```ts
+new MarkInputRule(/<b>(?<content>.*)<\/b>(?<trailing>)?$/u, schema.marks["bold"]);
+```
+
+Note that requiring trailing text is what lets a matcher with a variable-length delimiter resolve the delimiter unambiguously, so making `trailing` optional is only appropriate for marks with a fixed delimiter.
+
+Any other capturing groups are ignored, so they may be used freely.
+
 ### `createProseMirrorNode(nodeName: string | null, schema: Schema<string, string>, children: Array<ProseMirrorNode>, attrs: Attrs = {}): Array<ProseMirrorNode>`
 
 A helper function that creates a ProseMirror node based on `nodeName` with the specified children and attributes. Returns `[]` if `nodeName` is `null`. This function is useful when creating `NodeExtension`s

--- a/src/MarkInputRule.ts
+++ b/src/MarkInputRule.ts
@@ -11,6 +11,14 @@ export class MarkInputRule extends InputRule {
   private readonly markType: MarkType;
 
   public constructor(matcher: RegExp, markType: MarkType) {
+    if (
+      !matcher.source.includes("(?<content>") ||
+      !matcher.source.includes("(?<trailing>")
+    ) {
+      throw new Error(
+        'A MarkInputRule matcher must contain the named capturing groups "content" and "trailing".',
+      );
+    }
     super(matcher, (state, match, start, end) =>
       this.markHandler(state, match, start, end),
     );
@@ -45,6 +53,13 @@ export class MarkInputRule extends InputRule {
     start: number,
     end: number,
   ): Transaction | null {
+    // The constructor guarantees that both named groups are present in the matcher.
+    // The trailing group may be optional and therefore not participate in the match.
+    const { content, trailing } = match.groups as {
+      content: string;
+      trailing?: string;
+    };
+
     // Determine if mark applies to match
     const $start = state.doc.resolve(start);
     const $end = state.doc.resolve(end);
@@ -63,7 +78,7 @@ export class MarkInputRule extends InputRule {
     const tr = state.tr.replaceWith(
       start,
       end,
-      this.markType.schema.text(match[1]),
+      this.markType.schema.text(content),
     );
 
     // Add back all marks, including the new one
@@ -80,10 +95,10 @@ export class MarkInputRule extends InputRule {
       tr.removeStoredMark(markType);
     }
 
-    // Add back the last character if it is not a newline,
+    // Add back the trailing text if there is any and it is not a newline,
     // Otherwise omit it because newline is handled out of the text node.
-    if (match[2] !== "\n") {
-      tr.insertText(match[2]);
+    if (trailing !== undefined && trailing !== "\n") {
+      tr.insertText(trailing);
     }
 
     return tr;

--- a/tests/integration/BoldExtension.ts
+++ b/tests/integration/BoldExtension.ts
@@ -36,7 +36,7 @@ export class BoldExtension extends MarkExtension<UnistBold> {
   ): Array<InputRule> {
     return [
       new MarkInputRule(
-        /<b>([^\s](?:.*[^\s])?)<\/b>(.)$/u,
+        /<b>(?<content>[^\s](?:.*[^\s])?)<\/b>(?<trailing>.)$/u,
         proseMirrorSchema.marks[this.proseMirrorMarkName()],
       ),
     ];

--- a/tests/unit/MarkInputRule.test.ts
+++ b/tests/unit/MarkInputRule.test.ts
@@ -1,0 +1,136 @@
+import { inputRules } from "prosemirror-inputrules";
+import { type DOMOutputSpec, Schema } from "prosemirror-model";
+import { describe, expect, test } from "vitest";
+import { ProseMirrorTester } from "vitest-prosemirror";
+
+import { MarkInputRule } from "../../src/MarkInputRule";
+
+describe("MarkInputRule works", () => {
+  const errorMessage =
+    'A MarkInputRule matcher must contain the named capturing groups "content" and "trailing".';
+
+  const schema = new Schema({
+    marks: {
+      bold: { toDOM: (): DOMOutputSpec => ["b", 0] },
+    },
+    nodes: {
+      doc: { content: "paragraph+" },
+      paragraph: { content: "text*", toDOM: (): DOMOutputSpec => ["p", 0] },
+      text: {},
+    },
+  });
+
+  const typeText = (matcher: RegExp, text: string): ProseMirrorTester => {
+    const testEditor = new ProseMirrorTester(
+      schema.nodes.doc.create(null, schema.nodes.paragraph.create()),
+      {
+        plugins: [
+          inputRules({
+            rules: [new MarkInputRule(matcher, schema.marks.bold)],
+          }),
+        ],
+      },
+    );
+
+    testEditor.selectText("end");
+    testEditor.insertText(text);
+
+    return testEditor;
+  };
+
+  test("throws when the matcher is missing both named groups", () => {
+    expect.assertions(1);
+
+    expect(
+      () => new MarkInputRule(/<b>(.*)<\/b>(.)$/u, schema.marks.bold),
+    ).toThrow(errorMessage);
+  });
+
+  test("throws when the matcher is missing the content group", () => {
+    expect.assertions(1);
+
+    expect(
+      () =>
+        new MarkInputRule(/<b>(.*)<\/b>(?<trailing>.)$/u, schema.marks.bold),
+    ).toThrow(errorMessage);
+  });
+
+  test("throws when the matcher is missing the trailing group", () => {
+    expect.assertions(1);
+
+    expect(
+      () => new MarkInputRule(/<b>(?<content>.*)<\/b>(.)$/u, schema.marks.bold),
+    ).toThrow(errorMessage);
+  });
+
+  test("throws when a named group is misspelled", () => {
+    expect.assertions(1);
+
+    expect(
+      () =>
+        new MarkInputRule(
+          /<b>(?<content>.*)<\/b>(?<trailng>.)?$/u,
+          schema.marks.bold,
+        ),
+    ).toThrow(errorMessage);
+  });
+
+  test("strips the delimiters and applies the mark", () => {
+    expect.assertions(3);
+
+    const testEditor = typeText(
+      /<b>(?<content>.*)<\/b>(?<trailing>.)$/u,
+      "<b>bold</b> ",
+    );
+
+    expect(testEditor.doc.textContent).toBe("bold ");
+    expect(testEditor.doc.nodeAt(1)?.marks).toHaveLength(1);
+    expect(testEditor.doc.nodeAt(1)?.marks[0].type.name).toBe("bold");
+  });
+
+  test("works regardless of the capturing group indices", () => {
+    expect.assertions(2);
+
+    // The content group sits at index 2, after the backreferenced delimiter
+    const testEditor = typeText(
+      /(?<delimiter>`+)(?<content>[^`]+)\k<delimiter>(?<trailing>.)$/u,
+      "``code`` ",
+    );
+
+    expect(testEditor.doc.textContent).toBe("code ");
+    expect(testEditor.doc.nodeAt(1)?.marks).toHaveLength(1);
+  });
+
+  test("re-inserts a multi-character trailing match", () => {
+    expect.assertions(1);
+
+    expect(
+      typeText(/<b>(?<content>.*)<\/b>(?<trailing>\s\s)$/u, "<b>bold</b>  ").doc
+        .textContent,
+    ).toBe("bold  ");
+  });
+
+  test("works with an optional trailing group that does not match", () => {
+    expect.assertions(2);
+
+    const testEditor = typeText(
+      /<b>(?<content>.*)<\/b>(?<trailing>.)?$/u,
+      "<b>bold</b>",
+    );
+
+    expect(testEditor.doc.textContent).toBe("bold");
+    expect(testEditor.doc.nodeAt(1)?.marks).toHaveLength(1);
+  });
+
+  test("works with a matcher that has no trailing text at all", () => {
+    expect.assertions(2);
+
+    const testEditor = typeText(
+      /<b>(?<content>.*)<\/b>(?<trailing>)?$/u,
+      "<b>bold</b>",
+    );
+
+    expect(testEditor.doc.textContent).toBe("bold");
+    expect(testEditor.doc.nodeAt(1)?.marks).toHaveLength(1);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "forceConsistentCasingInFileNames": true,
     "module": "es6",
     "moduleResolution": "bundler",
-    "target": "es6",
+    "target": "es2018",
     "types": [],
 
     "allowUnreachableCode": false,


### PR DESCRIPTION
Requiring 2 named capture groups for `MarkInputRule` instead of relying on implicit ordering.

Closes #454.
