### PR TITLE
Removed obsolete strict

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,6 @@
     "noImplicitReturns": true,
     "noPropertyAccessFromIndexSignature": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "strict": true
+    "noUnusedParameters": true
   }
 }


### PR DESCRIPTION
`strict` is redundant on TypeScript 6, which enables it by default. Verified against 6.0.3 (the version this repo's lockfile resolves to) — with no `strict` set at all, a probe file still errors:

```
error TS7006: Parameter 'x' implicitly has an 'any' type.
error TS2322: Type 'null' is not assignable to type 'string'.
```

Same clean-up as skaut/crdm-modern@686dab5 and skaut/skautis-integration@e2050842, which this repo was missed by. This also makes the bottom block of the tsconfig identical to the other repos'.

Verified that the typecheck and eslint both still pass, and that strictness is still enforced afterwards.