### PR TITLE
Updated tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "es6",
+    "module": "esnext",
     "moduleResolution": "bundler",
     "target": "es2018",
     "types": [],


### PR DESCRIPTION
Brings the tsconfig top block in line with the other libraries — this was the last drift left after #992.

The same two changes marekdedic/vitest-prosemirror@4af614a made:

- `"module": "es6"` → `"esnext"`. This was the only config in any of the repos still on `es6`; every other non-`NodeNext` one uses `esnext`.
- dropped `esModuleInterop`, which vitest-prosemirror removed at the same time.

Unlike the `strict` removal in #992 these are real compiler options rather than redundant ones, so they were kept out of that PR and verified separately here. Before and after, on a clean tree:

| | baseline | this branch |
| - | - | - |
| `lint:typecheck` | pass | pass |
| `lint:eslint` | pass | pass |
| `test-coverage` | pass | pass |
| `build` | pass | pass |

Since this is a published package, I also diffed the build output: `dist/` is **byte-identical** before and after (`prosemirror-unified.js`, `.cjs`, `.d.ts`, `.d.cts`), so the published artifact does not change.