### PR TITLE
Removed obsolete types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,6 @@
     "module": "esnext",
     "moduleResolution": "bundler",
     "target": "es2018",
-    "types": [],
 
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,


### PR DESCRIPTION
`types` defaults to `[]` on TypeScript 6 — it no longer auto-includes every package under `node_modules/@types` — so this line states the default.

Verified against 6.0.3 in a repo with `@types/node` installed: referencing `process` fails with `TS2591` both when `types` is omitted and when it is `[]`, and resolves only with an explicit `types: ["'node']`. `tsc --all` documents no default for `--types`.

marekdedic/vitest-prosemirror already dropped its copy in #560.

Verified: the typecheck and build pass, and `dist/` is byte-identical.