### PR TITLE
Pin build.target so the ES2018 claim is actually true

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,6 +21,8 @@ export default defineConfig({
         "unified",
       ],
     },
+    // Matches `unified`, which ships ES2018.
+    target: "es2018",
   },
   plugins: [dts({ bundleTypes: true })],
   test: {


### PR DESCRIPTION
`tsconfig.json` has declared `"target": "es2018"` for a while, but under Vite that governs **typechecking only**. The actual emit came from Vite 8's default `build.target` of `baseline-widely-available`, which resolves to `chrome111, edge111, firefox114, safari16.4` — roughly ES2022.

So the published bundle has been shipping ES2022 while the repo claimed ES2018, and the real number would shift again on the next Vite major without anyone touching this repo.

## The fix

Setting `build.target: "es2018"` makes the declared level the actual one. Verified in `dist/`:

| | default (before) | `es2018` (after) |
|---|---|---|
| `?.` in bundle | present | downlevelled |
| `??` in bundle | present | downlevelled |

## Why ES2018 specifically

It is the level the surrounding ecosystem actually ships. I scanned the published packages:

- `unified` — ES2018
- `prosemirror-commands` — ES2018
- `prosemirror-model`, `prosemirror-view` — plain ES2015

Consumers re-bundle to their own target regardless, so the only real obligation is not out-running their parsers. Matching the ecosystem rather than exceeding it does that, and costs nothing.

## Verification

- `npm run lint` clean
- `npx vitest run` — 82 tests across 18 files pass
- `npm run build` produces both ESM and CJS as before