### PR TITLE
Test on all supported Node versions in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,9 +67,18 @@ jobs:
   test:
     name: "Test"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [22, 24, 26]
     steps:
       - name: "Checkout"
         uses: actions/checkout@v7.0.1
+
+      - name: "Setup Node"
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: "Cache NPM dependencies"
         uses: actions/cache@v6.1.0
@@ -91,6 +100,7 @@ jobs:
           npm run test unit
 
       - name: "Upload coverage results"
+        if: matrix.node-version == 26
         uses: codecov/codecov-action@v7.0.0
         with:
           flags: unit
@@ -102,6 +112,7 @@ jobs:
           npm run test integration
 
       - name: "Upload coverage results"
+        if: matrix.node-version == 26
         uses: codecov/codecov-action@v7.0.0
         with:
           flags: integration

--- a/package.json
+++ b/package.json
@@ -55,6 +55,9 @@
     "test": "vitest run --coverage",
     "test-watch": "vitest"
   },
+  "engines": {
+    "node": ">=22"
+  },
   "dependencies": {
     "@types/unist": "^3.0.0",
     "prosemirror-commands": "^1.5.1",


### PR DESCRIPTION
## Context

`.github/workflows/CI.yml` had no `actions/setup-node` step at all, so build/lint/test ran on whatever Node the `ubuntu-latest` runner happened to ship — an unpinned, undocumented version. Meanwhile `publish.yml` pins Node 24, and `package.json` declared no `engines.node`.

## Changes

- **`CI.yml` `test` job**: add a matrix over the supported even Node majors `[22, 24, 26]` (`fail-fast: false`) and an `actions/setup-node@v7` step. The existing manual `actions/cache` block is kept as-is. Both Codecov uploads are gated on `matrix.node-version == 26` so coverage is uploaded once, not three times.
- **`package.json`**: add `engines.node: ">=22"` to state the support range (v20 is EOL; 22/24 are LTS, 26 is Current).

Scope kept to the `test` job per the issue; `build`/`lint` are left on the runner default.

Closes #998