### PR TITLE
Enforce unused eslint-disable / inline-config directives

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,12 @@ export default tseslint.config(
   globalIgnores(["coverage/", "dist/", "package-lock.json"]),
   packageJson.configs.recommended,
   {
+    linterOptions: {
+      reportUnusedDisableDirectives: "error",
+      reportUnusedInlineConfigs: "error",
+    },
+  },
+  {
     extends: [json.configs.recommended],
     files: ["**/*.json"],
     ignores: ["package.json"],
@@ -56,7 +62,6 @@ export default tseslint.config(
       "default-case": "error",
       "default-case-last": "error",
       eqeqeq: "error",
-      "eslint-comments/no-unused-disable": "error",
       "eslint-comments/require-description": [
         "error",
         {


### PR DESCRIPTION
Two related changes:
- Sets `linterOptions.reportUnusedDisableDirectives: "error"` and `reportUnusedInlineConfigs: "error"` — both defaulted to `warn`.
- Removes `eslint-comments/no-unused-disable`, **deprecated since 4.7.0** and a no-op in flat config (patches `Linter#verify`, bypassed by flat config; `create()` returns `{}`). Replaced by the built-in `reportUnusedDisableDirectives`.

ESLint green.